### PR TITLE
Dust: update terraform to non-core tap

### DIFF
--- a/Formula/d/dust-tools.rb
+++ b/Formula/d/dust-tools.rb
@@ -47,7 +47,7 @@ class DustTools < Formula
     depends_on "tailwindcss"
     depends_on "templ"
     depends_on "temporal"
-    depends_on "terraform"
+    depends_on "hashicorp/tap/terraform"
     depends_on "terragrunt"
     depends_on "uv"
     depends_on "hashicorp/tap/vault"


### PR DESCRIPTION
Terraform changed it's license and is no longer allowed in Homebrew core